### PR TITLE
Bundle path information

### DIFF
--- a/FS.ios.js
+++ b/FS.ios.js
@@ -9,6 +9,7 @@ var _stat = Promise.promisify(RNFSManager.stat);
 var _readFile = Promise.promisify(RNFSManager.readFile);
 var _writeFile = Promise.promisify(RNFSManager.writeFile);
 var _unlink = Promise.promisify(RNFSManager.unlink);
+var _pathForBundle = Promise.promisify(RNFSManager.pathForBundle);
 
 var convertError = (err) => {
   if (err.isOperational) {
@@ -61,6 +62,10 @@ var RNFS = {
     return _writeFile(filepath, base64.encode(contents), options)
       .catch(convertError);
   },
+  
+  pathForBundle(bundleName) {
+  	return _pathForBundle(bundleName);
+  }
 
   unlink(filepath) {
     return _unlink(filepath)

--- a/NSArray+Map.m
+++ b/NSArray+Map.m
@@ -6,11 +6,14 @@
 
 @implementation NSArray (Map)
 
-- (NSArray *)rnfs_mapObjectsUsingBlock:(id (^)(id obj, NSUInteger idx))block {
+- (NSArray *)rnfs_mapObjectsUsingBlock:(id (^)(id obj, NSUInteger idx))block
+{
   NSMutableArray *result = [NSMutableArray arrayWithCapacity:[self count]];
+
   [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
     [result addObject:block(obj, idx)];
   }];
+
   return result;
 }
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -14,33 +14,36 @@
 
 static int MainBundleDirectory = 999;
 
-@synthesize bridge = _bridge;
 RCT_EXPORT_MODULE();
 
-- (dispatch_queue_t)methodQueue {
+- (dispatch_queue_t)methodQueue
+{
   return dispatch_queue_create("pe.lum.rnfs", DISPATCH_QUEUE_SERIAL);
 }
 
-RCT_EXPORT_METHOD(readDir:(NSString*)directory inFolder:(NSNumber*)folder callback:(RCTResponseSenderBlock)callback){
+RCT_EXPORT_METHOD(readDir:(NSString *)directory
+                  inFolder:(nonnull NSNumber *)folder
+                  callback:(RCTResponseSenderBlock)callback)
+{
   NSString *path;
-  int folderInt = [folder integerValue];
+  NSInteger folderInt = [folder integerValue];
 
   if (folderInt == MainBundleDirectory) {
     path = [[NSBundle mainBundle] bundlePath];
   } else {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(folderInt, NSUserDomainMask, YES);
-    path = [paths objectAtIndex:0];
+    path = [paths firstObject];
   }
 
   NSFileManager *fileManager = [NSFileManager defaultManager];
   NSError *error = nil;
-  NSString * dirPath = [path stringByAppendingPathComponent:directory];
+  NSString *dirPath = [path stringByAppendingPathComponent:directory];
   NSArray *contents = [fileManager contentsOfDirectoryAtPath:dirPath error:&error];
 
-  contents = [contents rnfs_mapObjectsUsingBlock:^id(id obj, NSUInteger idx) {
+  contents = [contents rnfs_mapObjectsUsingBlock:^id(NSString *obj, NSUInteger idx) {
     return @{
-      @"name": (NSString*)obj,
-      @"path": [dirPath stringByAppendingPathComponent:(NSString*)obj]
+      @"name": obj,
+      @"path": [dirPath stringByAppendingPathComponent:obj]
     };
   }];
 
@@ -51,7 +54,9 @@ RCT_EXPORT_METHOD(readDir:(NSString*)directory inFolder:(NSNumber*)folder callba
   callback(@[[NSNull null], contents]);
 }
 
-RCT_EXPORT_METHOD(stat:(NSString*)filepath callback:(RCTResponseSenderBlock)callback){
+RCT_EXPORT_METHOD(stat:(NSString *)filepath
+                  callback:(RCTResponseSenderBlock)callback)
+{
   NSError *error = nil;
   NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filepath error:&error];
 
@@ -60,17 +65,21 @@ RCT_EXPORT_METHOD(stat:(NSString*)filepath callback:(RCTResponseSenderBlock)call
   }
 
   attributes = @{
-    @"ctime": [self dateToTimeIntervalNumber:(NSDate*)[attributes objectForKey:NSFileCreationDate]],
-    @"mtime": [self dateToTimeIntervalNumber:(NSDate*)[attributes objectForKey:NSFileModificationDate]],
+    @"ctime": [self dateToTimeIntervalNumber:(NSDate *)[attributes objectForKey:NSFileCreationDate]],
+    @"mtime": [self dateToTimeIntervalNumber:(NSDate *)[attributes objectForKey:NSFileModificationDate]],
     @"size": [attributes objectForKey:NSFileSize],
     @"type": [attributes objectForKey:NSFileType],
-    @"mode": [NSNumber numberWithInteger:[[NSString stringWithFormat:@"%o", [(NSNumber*)[attributes objectForKey:NSFilePosixPermissions] integerValue]] integerValue]]
+    @"mode": @([[NSString stringWithFormat:@"%ld", (long)[(NSNumber *)[attributes objectForKey:NSFilePosixPermissions] integerValue]] integerValue])
   };
 
   callback(@[[NSNull null], attributes]);
 }
 
-RCT_EXPORT_METHOD(writeFile:(NSString*)filepath contents:(NSString*)base64Content attributes:(NSDictionary*)attributes callback:(RCTResponseSenderBlock)callback){
+RCT_EXPORT_METHOD(writeFile:(NSString *)filepath
+                  contents:(NSString *)base64Content
+                  attributes:(NSDictionary *)attributes
+                  callback:(RCTResponseSenderBlock)callback)
+{
   NSData *data = [[NSData alloc] initWithBase64EncodedString:base64Content options:NSDataBase64DecodingIgnoreUnknownCharacters];
   BOOL success = [[NSFileManager defaultManager] createFileAtPath:filepath contents:data attributes:attributes];
 
@@ -81,7 +90,9 @@ RCT_EXPORT_METHOD(writeFile:(NSString*)filepath contents:(NSString*)base64Conten
   callback(@[[NSNull null], [NSNumber numberWithBool:success]]);
 }
 
-RCT_EXPORT_METHOD(unlink:(NSString*)filepath callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(unlink:(NSString*)filepath
+                  callback:(RCTResponseSenderBlock)callback)
+{
   NSFileManager *manager = [NSFileManager defaultManager];
   BOOL exists = [manager fileExistsAtPath:filepath isDirectory:false];
 
@@ -98,7 +109,9 @@ RCT_EXPORT_METHOD(unlink:(NSString*)filepath callback:(RCTResponseSenderBlock)ca
   callback(@[[NSNull null], [NSNumber numberWithBool:success], filepath]);
 }
 
-RCT_EXPORT_METHOD(readFile:(NSString*)filepath callback:(RCTResponseSenderBlock)callback){
+RCT_EXPORT_METHOD(readFile:(NSString *)filepath
+                  callback:(RCTResponseSenderBlock)callback)
+{
   NSData *content = [[NSFileManager defaultManager] contentsAtPath:filepath];
   NSString *base64Content = [content base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
 
@@ -109,20 +122,35 @@ RCT_EXPORT_METHOD(readFile:(NSString*)filepath callback:(RCTResponseSenderBlock)
   callback(@[[NSNull null], base64Content]);
 }
 
-- (NSNumber*) dateToTimeIntervalNumber:(NSDate*)date {
-  return [NSNumber numberWithDouble:[date timeIntervalSince1970]];
+RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    NSString *path = [[NSBundle mainBundle].bundlePath stringByAppendingFormat:@"/%@.bundle", bundleNamed];
+    NSBundle *bundle = [NSBundle bundleWithPath:path];
+    if (!bundle.isLoaded) {
+        [bundle load];
+    }
+
+    callback(@[[NSNull null], path]);
 }
 
-- (NSArray*) makeErrorPayload:(NSError*)error {
+- (NSNumber *) dateToTimeIntervalNumber:(NSDate *)date
+{
+  return @([date timeIntervalSince1970]);
+}
+
+- (NSArray *)makeErrorPayload:(NSError *)error
+{
   return @[@{
     @"description": error.localizedDescription,
-    @"code": [NSNumber numberWithInteger:error.code]
+    @"code": @(error.code)
   }];
 }
 
-- (NSString*) getPathForDirectory:(int)directory {
+- (NSString *)getPathForDirectory:(int)directory
+{
   NSArray *paths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, YES);
-  return [paths objectAtIndex:0];
+  return [paths firstObject];
 }
 
 - (NSDictionary *)constantsToExport

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Native filesystem access for react-native",
   "main": "FS.ios.js",
   "scripts": {


### PR DESCRIPTION
Hey, what do you think of this? It fixes some warnings, fixes some potential crashes, and adds the ability to fetch path information for an arbitrary NSBundle.

The crash fixes are the use of firstObject, `objectAtIndex:0` can crash, but `firstObject` will just return nil.

Force of habit, I changed the style slightly while I was fixing the warnings. Hopefully not too presumptuous? 

It's not totally ready, (I need to test it much more thoroughly) but I wanted to open this PR to give you a chance to look at it, before I wrapped it up