### PR TITLE
Update to load Bundles by their class name if not found in typical bundle path.

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -127,6 +127,11 @@ RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
 {
     NSString *path = [[NSBundle mainBundle].bundlePath stringByAppendingFormat:@"/%@.bundle", bundleNamed];
     NSBundle *bundle = [NSBundle bundleWithPath:path];
+
+    if (!bundle) {
+        bundle = [NSBundle bundleForClass:NSClassFromString(bundleNamed)];
+    }
+    
     if (!bundle.isLoaded) {
         [bundle load];
     }
@@ -134,7 +139,7 @@ RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
     callback(@[[NSNull null], path]);
 }
 
-- (NSNumber *) dateToTimeIntervalNumber:(NSDate *)date
+- (NSNumber *)dateToTimeIntervalNumber:(NSDate *)date
 {
   return @([date timeIntervalSince1970]);
 }

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -137,7 +137,14 @@ RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
         [bundle load];
     }
 
-    callback(@[[NSNull null], path]);
+    if (path) {
+        callback(@[[NSNull null], path]);
+    } else {
+        callback(@[[NSError errorWithDomain:NSPOSIXErrorDomain
+                                       code:NSFileNoSuchFileError
+                                   userInfo:nil].localizedDescription,
+                   [NSNull null]]);
+    }
 }
 
 - (NSNumber *)dateToTimeIntervalNumber:(NSDate *)date

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -130,6 +130,7 @@ RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
 
     if (!bundle) {
         bundle = [NSBundle bundleForClass:NSClassFromString(bundleNamed)];
+        path = bundle.bundlePath;
     }
     
     if (!bundle.isLoaded) {


### PR DESCRIPTION
This is mainly for dynamic/embedded frameworks. While they can be loaded as an NSBundle, they're not in the typical path.