### PR TITLE
Requiring internal react-native modules will stop working

### DIFF
--- a/FS.ios.js
+++ b/FS.ios.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var RNFSManager = require('NativeModules').RNFSManager;
+var RNFSManager = require('react-native').NativeModules.RNFSManager;
 var Promise = require('bluebird');
 var base64 = require('base-64');
 


### PR DESCRIPTION
`require('NativeModules')` now creates this warning:

```
Unable to resolve module NativeModules from /Users/jameszhang/Documents/thedrop/TheArtistUnion/node_modules/react-native-fs/FS.ios.js
```

And should be replaced with `require('react-native').NativeModules`

Issue originally reported here: https://github.com/facebook/react-native/issues/1808