### PR TITLE
Add shouldEncode option to writeFile

### DIFF
--- a/FS.ios.js
+++ b/FS.ios.js
@@ -58,8 +58,12 @@ var RNFS = {
     return p.catch(convertError);
   },
 
-  writeFile(filepath, contents, options) {
-    return _writeFile(filepath, base64.encode(contents), options)
+  writeFile(filepath, contents, shouldEncode, options) {
+    var contents;
+    if (shouldEncode !== false) {
+      contents = base64.encode(contents);
+    }
+    return _writeFile(filepath, contents, options)
       .catch(convertError);
   },
 


### PR DESCRIPTION
I encountered a scenario where I was trying to write a file and noticed that the app used 4x normal memory usage with `writeFile`. The content was already Base64 encoded so I decoded it and then used it as the `contents` argument in `writeFile`. Then, `writeFile` encodes `contents` and calls `RNFSManager.writeFile`, which actually writes the file to the document store by initiating `NSData` with `initWithBase64EncodedString`.

All of this can be simplified if there was a `shouldEncode` option on `writeFile`. If you think this scenario isn't too common, let me know and I'll just a forked version of this library.