### PR TITLE
Adding Android constants

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -177,7 +177,8 @@ var RNFS = {
   MainBundlePath: RNFSManager.MainBundlePath,
   CachesDirectoryPath: RNFSManager.NSCachesDirectoryPath,
   DocumentDirectoryPath: RNFSManager.NSDocumentDirectoryPath,
-  LibraryDirectoryPath: RNFSManager.NSLibraryDirectoryPath
+  LibraryDirectoryPath: RNFSManager.NSLibraryDirectoryPath,
+  PicturesDirectoryPath: RNFSManager.NSPicturesDirectoryPath
 };
 
 module.exports = RNFS;

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.rnfs" >
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -38,6 +38,8 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class RNFSManager extends ReactContextBaseJavaModule {
 
   private static final String NSDocumentDirectoryPath = "NSDocumentDirectoryPath";
+  private static final String NSPicturesDirectoryPath = "NSPicturesDirectoryPath";
+  private static final String NSCachesDirectoryPath = "NSCachesDirectoryPath";
   private static final String NSDocumentDirectory = "NSDocumentDirectory";
 
   private static final String NSFileTypeRegular = "NSFileTypeRegular";
@@ -281,6 +283,8 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     final Map<String, Object> constants = new HashMap<>();
     constants.put(NSDocumentDirectory, 0);
     constants.put(NSDocumentDirectoryPath, this.getReactApplicationContext().getFilesDir().getAbsolutePath());
+    constants.put(NSPicturesDirectoryPath, Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).getAbsolutePath());
+    constants.put(NSCachesDirectoryPath, this.getReactApplicationContext().getCacheDir().getAbsolutePath());
     constants.put(NSFileTypeRegular, 0);
     constants.put(NSFileTypeDirectory, 1);
     return constants;


### PR DESCRIPTION
fixed CachesDirectoryPath (working on Android and iOS)
and added PicturesDirectoryPath (Android only)
require write permission on external storage in Android Manifest file