### PR TITLE
add move file method

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -18,6 +18,7 @@ var _readDir = Promise.promisify(RNFSManager.readDir);
 var _stat = Promise.promisify(RNFSManager.stat);
 var _readFile = Promise.promisify(RNFSManager.readFile);
 var _writeFile = Promise.promisify(RNFSManager.writeFile);
+var _moveFile = Promise.promisify(RNFSManager.moveFile);
 var _unlink = Promise.promisify(RNFSManager.unlink);
 var _mkdir = Promise.promisify(RNFSManager.mkdir);
 var _downloadFile = Promise.promisify(RNFSManager.downloadFile);
@@ -120,6 +121,11 @@ var RNFS = {
     }
 
     return _writeFile(filepath, b64, options)
+      .catch(convertError);
+  },
+
+  moveFile(filepath, topath) {
+    return _moveFile(filepath, topath)
       .catch(convertError);
   },
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -148,6 +148,22 @@ RCT_EXPORT_METHOD(readFile:(NSString *)filepath
   callback(@[[NSNull null], base64Content]);
 }
 
+RCT_EXPORT_METHOD(moveFile:(NSString *)filepath
+                  topath:(NSString *)topath
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    NSFileManager *manager = [NSFileManager defaultManager];
+    
+    NSError *error = nil;
+    BOOL success = [manager moveItemAtPath:filepath toPath:topath error:&error];
+    
+    if (!success) {
+        return callback([self makeErrorPayload:error]);
+    }
+    
+    callback(@[[NSNull null], [NSNumber numberWithBool:success], filepath]);
+}
+
 RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
                   filepath:(NSString *)filepath
                   jobId:(nonnull NSNumber *)jobId


### PR DESCRIPTION
This adds a new method for moving a file (or renaming a file). It's only iOS though (I don't really know java). 

```javascript
 RNFS.moveFile(sourcePath, destPath);
```