### PR TITLE
fix error caused by when `bytesWritten` is null

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -160,9 +160,12 @@ RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
   params.toFile = filepath;
 
   params.callback = ^(NSNumber* statusCode, NSNumber* bytesWritten) {
-    return callback(@[[NSNull null], @{@"jobId": jobId,
-                                       @"statusCode": statusCode,
-                                       @"bytesWritten": bytesWritten}]);
+    NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,
+                             @"statusCode": statusCode}];
+    if (bytesWritten) {
+      [result setObject:@"bytesWritten" forKey: bytesWritten];
+    }
+    return callback(@[[NSNull null], result]);
   };
 
   params.errorCallback = ^(NSError* error) {

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -163,7 +163,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,
                              @"statusCode": statusCode}];
     if (bytesWritten) {
-      [result setObject:@"bytesWritten" forKey: bytesWritten];
+      [result setObject:bytesWritten forKey: @"bytesWritten"];
     }
     return callback(@[[NSNull null], result]);
   };


### PR DESCRIPTION
Fix error  caused by when  `bytesWritten` is null.
issue #44 