### PR TITLE
Update Readme.md re: new react-native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ dependencies {
 ```
 
 * register module (in MainActivity.java)
+ 
+  * For react-native below 0.19.0 (use `cat ./node_modules/react-native/package.json | grep version`)
 
 ```java
 import com.rnfs.RNFSPackage;  // <--- import
@@ -72,6 +74,21 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
   ......
 
 }
+```
+
+  * For react-native 0.19.0 and higher
+```java
+import com.rnfs.RNFSPackage; // <------- add package
+
+public class MainActivity extends ReactActivity {
+   // ...
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
+        new MainReactPackage(), // <---- add comma
+        new RNFSPackage() // <---------- add package
+      );
+    }
 ```
 
 ## Examples


### PR DESCRIPTION
react-native now uses `getPackages()` to return an array of package objects instead of overriding `onCreate()`.