### PR TITLE
new getFSInfo command

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -24,6 +24,7 @@ var _unlink = Promise.promisify(RNFSManager.unlink);
 var _mkdir = Promise.promisify(RNFSManager.mkdir);
 var _downloadFile = Promise.promisify(RNFSManager.downloadFile);
 var _pathForBundle = Promise.promisify(RNFSManager.pathForBundle);
+var _getFSInfo = Promise.promisify(RNFSManager.getFSInfo);
 
 var convertError = (err) => {
   if (err.isOperational && err.cause) {
@@ -83,7 +84,7 @@ var RNFS = {
       })
       .catch(convertError);
   },
-  
+
   exists(filepath) {
     return _exists(filepath)
       .catch(convertError);
@@ -137,6 +138,11 @@ var RNFS = {
 
   pathForBundle(bundleName) {
     return _pathForBundle(bundleName);
+  },
+
+  getFSInfo() {
+    return _getFSInfo()
+      .catch(convertError);
   },
 
   unlink(filepath) {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dependencies {
 ```
 
 * register module (in MainActivity.java)
- 
+
   * For react-native below 0.19.0 (use `cat ./node_modules/react-native/package.json | grep version`)
 
 ```java
@@ -254,6 +254,13 @@ Percentage can be computed easily by dividing `bytesWritten` by `contentLength`.
 ### `void stopDownload(jobId)`
 
 Abort the current download job with this ID. The partial file will remain on the filesystem.
+
+### `promise getFSInfo()`
+
+Returns an object with the following properties:
+
+`totalSpace` (`Number`): The total amount of storage space on the device (in bytes).
+`freeSpace` (`Number`): The amount of available storage space on the device (in bytes).
 
 ## Test / Demo app
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -253,6 +253,32 @@ RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
     }
 }
 
+RCT_EXPORT_METHOD(getFSInfo:(RCTResponseSenderBlock)callback)
+{
+    unsigned long long totalSpace = 0;
+    unsigned long long totalFreeSpace = 0;
+    
+    __autoreleasing NSError *error = nil;
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSDictionary *dictionary = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject] error: &error];
+    
+    if (dictionary) {
+        NSNumber *fileSystemSizeInBytes = [dictionary objectForKey: NSFileSystemSize];
+        NSNumber *freeFileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemFreeSize];
+        totalSpace = [fileSystemSizeInBytes unsignedLongLongValue];
+        totalFreeSpace = [freeFileSystemSizeInBytes unsignedLongLongValue];
+        
+        callback(@[[NSNull null],
+                   @{
+                       @"totalSpace": [NSNumber numberWithUnsignedLongLong:totalSpace],
+                       @"freeSpace": [NSNumber numberWithUnsignedLongLong:totalFreeSpace]
+                       }
+                   ]);
+    } else {
+        callback(@[error, [NSNull null]]);
+    }
+}
+
 - (NSNumber *)dateToTimeIntervalNumber:(NSDate *)date
 {
   return @([date timeIntervalSince1970]);

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 
 import android.os.Environment;
 import android.os.AsyncTask;
+import android.os.StatFs;
 import android.util.Base64;
 import android.content.Context;
 import android.support.annotation.Nullable;
@@ -295,6 +296,26 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   @ReactMethod
   public void pathForBundle(String bundleNamed, Callback callback) {
     // TODO: Not sure what equilivent would be?
+  }
+
+  @ReactMethod
+  public void getFSInfo(Callback callback) {
+    File path = Environment.getDataDirectory();
+    StatFs stat = new StatFs(path.getPath());
+    long totalSpace;
+    long freeSpace;
+    if (android.os.Build.VERSION.SDK_INT >= 18) {
+      totalSpace = stat.getTotalBytes();
+      freeSpace = stat.getFreeBytes();
+    } else {
+      long blockSize = stat.getBlockSize();
+      totalSpace = blockSize * stat.getBlockCount();
+      freeSpace = blockSize * stat.getAvailableBlocks();
+    }
+    HashMap info = new HashMap();
+    info.put("totalSpace", totalSpace);
+    info.put("freeSpace", freeSpace);
+    callback.invoke(null, info);
   }
 
   private WritableMap makeErrorPayload(Exception ex) {


### PR DESCRIPTION
This creates a new `getFSInfo()` command. Its call signature is as follows (which I've also added to the docs):

### `promise getFSInfo()`

Returns an object with the following properties:

`totalSpace` (`Number`): The total amount of storage space on the device (in bytes).
`freeSpace` (`Number`): The amount of available storage space on the device (in bytes).

I've tested this in iOS and it works fine. Haven't had a chance to test in Android because I'm having emulator issues, but it is implemented. If someone else could test that I'd appreciate it.