### PR TITLE
downloadFile: avoid connecting twice for each download on Android

### DIFF
--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -64,7 +64,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
 
       mParam.onDownloadBegin.onDownloadBegin(statusCode, lengthOfFile, headersFlat);
 
-      input = new BufferedInputStream(param.src.openStream(), 8 * 1024);
+      input = new BufferedInputStream(connection.getInputStream(), 8 * 1024);
       output = new FileOutputStream(param.dest);
 
       byte data[] = new byte[8 * 1024];


### PR DESCRIPTION
A connection already exists to fetch HTTP headers, so use that to complete the
download instead of making a second connection.