### PR TITLE
Give android access to getExternalFilesDir

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -189,6 +189,7 @@ var RNFS = {
   MainBundlePath: RNFSManager.MainBundlePath,
   CachesDirectoryPath: RNFSManager.NSCachesDirectoryPath,
   DocumentDirectoryPath: RNFSManager.NSDocumentDirectoryPath,
+  ExternalDirectoryPath: RNFSManager.NSExternalDirectoryPath,
   LibraryDirectoryPath: RNFSManager.NSLibraryDirectoryPath,
   PicturesDirectoryPath: RNFSManager.NSPicturesDirectoryPath
 };

--- a/IntegrationTests/FSTest.js
+++ b/IntegrationTests/FSTest.js
@@ -63,7 +63,7 @@ function testWriteAndReadFile() {
 
 
 function testCreateAndDeleteFile() {
-  var path = RNFS.ExternalDirectoryPath + '/test.txt';
+  var path = RNFS.DocumentDirectoryPath + '/test.txt';
   var text = 'Lorem ipsum dolor sit amet';
   var readText;
 

--- a/IntegrationTests/FSTest.js
+++ b/IntegrationTests/FSTest.js
@@ -63,7 +63,7 @@ function testWriteAndReadFile() {
 
 
 function testCreateAndDeleteFile() {
-  var path = RNFS.DocumentDirectoryPath + '/test.txt';
+  var path = RNFS.ExternalDirectoryPath + '/test.txt';
   var text = 'Lorem ipsum dolor sit amet';
   var readText;
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The following constants are available on the `RNFS` export:
 `MainBundlePath` (`String`) The absolute path to the main bundle directory  
 `CachesDirectoryPath` (`String`) The absolute path to the caches directory  
 `DocumentDirectoryPath`  (`String`) The absolute path to the document directory
+`ExternalDirectoryPath` (`String`) The absolute path to the external, shared directory (android only)
 
 ### `promise readDir(path)`
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -278,6 +278,7 @@ RCT_EXPORT_METHOD(pathForBundle:(NSString *)bundleNamed
     @"MainBundlePath": [[NSBundle mainBundle] bundlePath],
     @"NSCachesDirectoryPath": [self getPathForDirectory:NSCachesDirectory],
     @"NSDocumentDirectoryPath": [self getPathForDirectory:NSDocumentDirectory],
+    @"NSExternalDirectoryPath": [NSNull null],
     @"NSLibraryDirectoryPath": [self getPathForDirectory:NSLibraryDirectory],
     @"NSFileTypeRegular": NSFileTypeRegular,
     @"NSFileTypeDirectory": NSFileTypeDirectory

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -38,6 +38,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class RNFSManager extends ReactContextBaseJavaModule {
 
   private static final String NSDocumentDirectoryPath = "NSDocumentDirectoryPath";
+  private static final String NSExternalDirectoryPath = "NSExternalDirectoryPath";
   private static final String NSPicturesDirectoryPath = "NSPicturesDirectoryPath";
   private static final String NSCachesDirectoryPath = "NSCachesDirectoryPath";
   private static final String NSDocumentDirectory = "NSDocumentDirectory";
@@ -308,6 +309,12 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     final Map<String, Object> constants = new HashMap<>();
     constants.put(NSDocumentDirectory, 0);
     constants.put(NSDocumentDirectoryPath, this.getReactApplicationContext().getFilesDir().getAbsolutePath());
+    File externalDirectory = this.getReactApplicationContext().getExternalFilesDir(null);
+    if (externalDirectory != null) {
+        constants.put(NSExternalDirectoryPath, externalDirectory.getAbsolutePath());
+    } else {
+        constants.put(NSExternalDirectoryPath, null);
+    }
     constants.put(NSPicturesDirectoryPath, Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES).getAbsolutePath());
     constants.put(NSCachesDirectoryPath, this.getReactApplicationContext().getCacheDir().getAbsolutePath());
     constants.put(NSFileTypeRegular, 0);


### PR DESCRIPTION
Much like e.g. `RNFS.DocumentDirectoryPath`, use [getExternalFilesDir](http://developer.android.com/reference/android/content/Context.html#getExternalFilesDir(java.lang.String)) to get the abs path to shared storage. Set to null for iOS or when there is no external storage.

Motivation:
> External storage is the best place for files that don't require access restrictions and for files that you want to share with other apps or allow the user to access with a computer.
