### PR TITLE
Android assets support

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -168,6 +168,20 @@ var RNFS = {
     });
   },
 
+  // Android-only
+  readDirAssets(dirpath): Promise<ReadDirItem[]> {
+    return RNFSManager.readDirAssets(dirpath).then(files => {
+          return files.map(file => ({
+            name: file.name,
+            path: file.path,
+            size: file.size,
+            isFile: () => file.type === NSFileTypeRegular,
+            isDirectory: () => file.type === NSFileTypeDirectory,
+          }));
+        })
+        .catch(convertError)
+  },
+
   // Node style version (lowercase d). Returns just the names
   readdir(dirpath: string): Promise<string[]> {
     return RNFS.readDir(normalizeFilePath(dirpath)).then(files => {

--- a/FS.common.js
+++ b/FS.common.js
@@ -242,6 +242,15 @@ var RNFS = {
     return RNFSManager.hash(filepath, algorithm);
   },
 
+  // Android only
+  copyFileAssets(filepath, destination) {
+    if (!_copyFileAssets) {
+      throw new Error("Not available on this platform");
+    }
+    return _copyFileAssets(filepath, destination)
+        .catch(convertError);
+  },
+
   writeFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
     var b64;
 

--- a/FS.common.js
+++ b/FS.common.js
@@ -211,15 +211,15 @@ var RNFS = {
   // Android-only
   readDirAssets(dirpath: string): Promise<ReadDirItem[]> {
     if (!RNFSManager.readDirAssets) {
-      throw new Error('Not available on this platform');
+      throw new Error('readDirAssets is not available on this platform');
     }
     return readDirGeneric(dirpath, RNFSManager.readDirAssets);
   },
 
   // Android-only
   existsAssets(filepath: string) {
-    if (!RNFSManager.readFileAssets) {
-      throw new Error('Not available on this platform');
+    if (!RNFSManager.existsAssets) {
+      throw new Error('existsAssets is not available on this platform');
     }
     return RNFSManager.existsAssets(filepath);
   },
@@ -251,7 +251,7 @@ var RNFS = {
   // Android only
   readFileAssets(filepath: string, encodingOrOptions?: any): Promise<string> {
     if (!RNFSManager.readFileAssets) {
-      throw new Error('Not available on this platform');
+      throw new Error('readFileAssets is not available on this platform');
     }
     return readFileGeneric(filepath, encodingOrOptions, RNFSManager.readFileAssets);
   },
@@ -263,7 +263,7 @@ var RNFS = {
   // Android only
   copyFileAssets(filepath: string, destPath:string) {
     if (!RNFSManager.copyFileAssets) {
-      throw new Error('Not available on this platform');
+      throw new Error('copyFileAssets is not available on this platform');
     }
     return RNFSManager.copyFileAssets(normalizeFilePath(filepath), normalizeFilePath(destPath)).then(() => void 0);
   },

--- a/FS.common.js
+++ b/FS.common.js
@@ -226,7 +226,7 @@ var RNFS = {
 
   // Node style version (lowercase d). Returns just the names
   readdir(dirpath: string): Promise<string[]> {
-    return RNFSManager.readDir(normalizeFilePath(dirpath)).then(files => {
+    return RNFS.readDir(normalizeFilePath(dirpath)).then(files => {
       return files.map(file => file.name);
     });
   },

--- a/FS.common.js
+++ b/FS.common.js
@@ -232,6 +232,12 @@ var RNFS = {
     });
   },
 
+
+  // Android only
+  readFileAssets(filepath, encoding) {
+    return readFileActual(filepath, encoding, _readFileAssets);
+  },
+
   hash(filepath: string, algorithm: string): Promise<string> {
     return RNFSManager.hash(filepath, algorithm);
   },

--- a/FS.common.js
+++ b/FS.common.js
@@ -182,6 +182,12 @@ var RNFS = {
         .catch(convertError)
   },
 
+  // Android-only
+  existsAssets(filepath) {
+    return _existsAssets(filepath)
+      .catch(convertError);
+  },
+
   // Node style version (lowercase d). Returns just the names
   readdir(dirpath: string): Promise<string[]> {
     return RNFS.readDir(normalizeFilePath(dirpath)).then(files => {

--- a/README.md
+++ b/README.md
@@ -297,22 +297,30 @@ type ReadDirItem = {
 };
 ```
 
-### `readdir(dirpath: string): Promise<string[]>`
+### `readDirAssets(dirpath: string): Promise<ReadDirItem[]>`
 
-Node.js style version of `readDir` that returns only the names. Note the lowercase `d`.
-
-### `promise readDirAssets(path)`
-
-Reads the contents of `path` in the Android app's assets folder.
-`path` is the relative path to the file from the root of the `assets` folder.
+Reads the contents of `dirpath ` in the Android app's assets folder.
+`dirpath ` is the relative path to the file from the root of the `assets` folder.
 
 The returned promise resolves with an array of objects with the following properties:
 
-`name` (`String`) - The name of the item
-`path` (`String`) - The absolute path to the item
-`size` (`Number`) - Size in bytes. Note that the size of files compressed during the creation of the APK (such as JSON files) cannot be determined. `size` will be set to -1 in this case.
+```
+type ReadDirItem = {
+  name: string;     // The name of the item
+  path: string;     // The absolute path to the item
+  size: string;     // Size in bytes. 
+  						// Note that the size of files compressed during the creation of the APK (such as JSON files) cannot be determined. 
+  						// `size` will be set to -1 in this case.
+  isFile: () => boolean;        // Is the file just a file?
+  isDirectory: () => boolean;   // Is the file a directory?
+};
+```
 
 Note: Android only.
+
+### `readdir(dirpath: string): Promise<string[]>`
+
+Node.js style version of `readDir` that returns only the names. Note the lowercase `d`.
 
 ### `stat(filepath: string): Promise<StatResult>`
 
@@ -336,37 +344,17 @@ Reads the file at `path` and return contents. `encoding` can be one of `utf8` (d
 
 Note: you will take quite a performance hit if you are reading big files
 
-### `promise readFileAssets(path, [, encoding]`
+### `readFileAssets(filepath:string, encoding?: string): Promise<string>`
 
 Reads the file at `path` in the Android app's assets folder and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
 
-`path` is the relative path to the file from the root of the `assets` folder.
+`filepath` is the relative path to the file from the root of the `assets` folder.
 
 Note: Android only.
 
 ### `writeFile(filepath: string, contents: string, encoding?: string): Promise<void>`
 
 Write the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`. `options` optionally takes an object specifying the file's properties, like mode etc.
-
-### `promise copyFile(source, destination)`
-
-Copies the file at `source` in the file system and copies it to the given `destination` path.
-
-`source` (`String`) is the absolute path to the source file.
-
-`destination` (`String`) is the absolute path to the destination including the filename.
-
-NOTE: On Android copyFile will always overwrite the destination. On iOS an error will be thrown if the file already exists.
-
-### `promise copyFileAssets(source, destination)`
-
-Copies the file at `source` in the Android app's assets folder and copies it to the given `destination` path.
-
-`source` (`String`) is the relative path to the file from the root of the `assets` folder.
-
-`destination` (`String`) is the absolute path to the destination including the filename.
-
-Note: Android only. Will overwrite the file if it's already there.
 
 ### `appendFile(filepath: string, contents: string, encoding?: string): Promise<void>`
 
@@ -380,6 +368,14 @@ Moves the file located at `filepath` to `destPath`. This is more performant than
 
 Copies the file located at `filepath` to `destPath`.
 
+Note: On Android copyFile will overwrite `destPath` if it already exists. On iOS an error will be thrown if the file already exists.
+
+### `copyFileAssets(filepath: string, destPath: string): Promise<void>`
+
+Copies the file at `filepath ` in the Android app's assets folder and copies it to the given `destPath ` path.
+
+Note: Android only. Will overwrite destPath if it already exists
+
 ### `unlink(filepath: string): Promise<void>`
 
 Unlinks the item at `filepath`. If the item does not exist, an error will be thrown.
@@ -388,7 +384,11 @@ Also recursively deletes directories (works like Linux `rm -rf`).
 
 ### `exists(filepath: string): Promise<boolean>`
 
-check if the item exist at `filepath`. If the item does not exist, return false.
+Check if the item exists at `filepath`. If the item does not exist, return false.
+
+### `existsAssets(filepath: string): Promise<boolean>`
+
+Check in the Android assets folder if the item exists. `filepath` is the relative path from the root of the assets folder. If the item does not exist, return false.
 
 ### `hash(filepath: string, algorithm: string): Promise<string>`
 
@@ -401,13 +401,6 @@ type MkdirOptions = {
   NSURLIsExcludedFromBackupKey?: boolean; // iOS only
 };
 ```
-### `promise existsAssets(filepath)`
-
-check if the Android asset exists at the given `filepath`. If the item does not exist, returns false.
-
-The promise resolves with boolean.
-
-`filepath ` (`String`) is the relative path to the file from the root of the `assets` folder.
 
 ### `promise mkdir(filepath [, excludeFromBackup])`
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,15 @@ type MkdirOptions = {
   NSURLIsExcludedFromBackupKey?: boolean; // iOS only
 };
 ```
+### `promise existsAssets(filepath)`
+
+check if the Android asset exists at the given `filepath`. If the item does not exist, returns false.
+
+The promise resolves with boolean.
+
+`filepath ` (`String`) is the relative path to the file from the root of the `assets` folder.
+
+### `promise mkdir(filepath [, excludeFromBackup])`
 
 Create a directory at `filepath`. Automatically creates parents and does not throw if already exists (works like Linux `mkdir -p`).
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,16 @@ Note: Android only.
 
 Write the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`. `options` optionally takes an object specifying the file's properties, like mode etc.
 
+### `promise copyFile(source, destination)`
+
+Copies the file at `source` in the file system and copies it to the given `destination` path.
+
+`source` (`String`) is the absolute path to the source file.
+
+`destination` (`String`) is the absolute path to the destination including the filename.
+
+NOTE: On Android copyFile will always overwrite the destination. On iOS an error will be thrown if the file already exists.
+
 ### `promise copyFileAssets(source, destination)`
 
 Copies the file at `source` in the Android app's assets folder and copies it to the given `destination` path.
@@ -356,7 +366,7 @@ Copies the file at `source` in the Android app's assets folder and copies it to 
 
 `destination` (`String`) is the absolute path to the destination including the filename.
 
-Note: Android only.
+Note: Android only. Will overwrite the file if it's already there.
 
 ### `appendFile(filepath: string, contents: string, encoding?: string): Promise<void>`
 

--- a/README.md
+++ b/README.md
@@ -402,8 +402,6 @@ type MkdirOptions = {
 };
 ```
 
-### `promise mkdir(filepath [, excludeFromBackup])`
-
 Create a directory at `filepath`. Automatically creates parents and does not throw if already exists (works like Linux `mkdir -p`).
 
 (IOS only): The `NSURLIsExcludedFromBackupKey` property can be provided to set this attribute on iOS platforms. Apple will *reject* apps for storing offline cache data that does not have this attribute.

--- a/README.md
+++ b/README.md
@@ -301,6 +301,19 @@ type ReadDirItem = {
 
 Node.js style version of `readDir` that returns only the names. Note the lowercase `d`.
 
+### `promise readDirAssets(path)`
+
+Reads the contents of `path` in the Android app's assets folder.
+`path` is the relative path to the file from the root of the `assets` folder.
+
+The returned promise resolves with an array of objects with the following properties:
+
+`name` (`String`) - The name of the item
+`path` (`String`) - The absolute path to the item
+`size` (`Number`) - Size in bytes. Note that the size of files compressed during the creation of the APK (such as JSON files) cannot be determined. `size` will be set to -1 in this case.
+
+Note: Android only.
+
 ### `stat(filepath: string): Promise<StatResult>`
 
 Stats an item at `path`.
@@ -322,6 +335,14 @@ type StatResult = {
 Reads the file at `path` and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
 
 Note: you will take quite a performance hit if you are reading big files
+
+### `promise readFileAssets(path, [, encoding]`
+
+Reads the file at `path` in the Android app's assets folder and return contents. `encoding` can be one of `utf8` (default), `ascii`, `base64`. Use `base64` for reading binary files.
+
+`path` is the relative path to the file from the root of the `assets` folder.
+
+Note: Android only.
 
 ### `writeFile(filepath: string, contents: string, encoding?: string): Promise<void>`
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,16 @@ Note: Android only.
 
 Write the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`. `options` optionally takes an object specifying the file's properties, like mode etc.
 
+### `promise copyFileAssets(source, destination)`
+
+Copies the file at `source` in the Android app's assets folder and copies it to the given `destination` path.
+
+`source` (`String`) is the relative path to the file from the root of the `assets` folder.
+
+`destination` (`String`) is the absolute path to the destination including the filename.
+
+Note: Android only.
+
 ### `appendFile(filepath: string, contents: string, encoding?: string): Promise<void>`
 
 Append the `contents` to `filepath`. `encoding` can be one of `utf8` (default), `ascii`, `base64`.

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -258,11 +258,12 @@ public class RNFSManager extends ReactContextBaseJavaModule {
         WritableMap fileMap = Arguments.createMap();
 
         fileMap.putString("name", childFile);
-        fileMap.putString("path", childFile);
+        String path = String.format("%s/%s", directory, childFile);
+        fileMap.putString("path", path);
         int length = 0;
         boolean isDirectory = false;
         try {
-          AssetFileDescriptor assetFileDescriptor = assetManager.openFd(childFile);
+          AssetFileDescriptor assetFileDescriptor = assetManager.openFd(path);
           if (assetFileDescriptor != null) {
             length = (int) assetFileDescriptor.getLength();
             assetFileDescriptor.close();

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -129,6 +129,36 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void readFileAssets(String filepath, Callback callback) {
+    InputStream stream = null;
+    try {
+      // ensure isn't a directory
+      AssetManager assetManager = getReactApplicationContext().getAssets();
+      stream = assetManager.open(filepath, 0);
+      if (stream == null) {
+        callback.invoke(makeErrorPayload(new Exception("Failed to open file")));
+        return;
+      }
+
+      byte[] buffer = new byte[stream.available()];
+      stream.read(buffer);
+      String base64Content = Base64.encodeToString(buffer, Base64.NO_WRAP);
+
+      callback.invoke(null, base64Content);
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      callback.invoke(makeErrorPayload(ex));
+    } finally {
+      if (stream != null) {
+        try {
+          stream.close();
+        } catch (IOException ignored) {
+        }
+      }
+    }
+  }
+
+  @ReactMethod
   public void hash(String filepath, String algorithm, Promise promise) {
     try {
       Map<String, String> algorithms = new HashMap<>();

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -9,6 +9,8 @@ import android.os.StatFs;
 import android.util.Base64;
 import android.support.annotation.Nullable;
 import android.util.SparseArray;
+import android.content.res.AssetFileDescriptor;
+import android.content.res.AssetManager;
 
 import java.io.File;
 import java.io.OutputStream;
@@ -242,6 +244,43 @@ public class RNFSManager extends ReactContextBaseJavaModule {
     } catch (Exception ex) {
       ex.printStackTrace();
       reject(promise, directory, ex);
+    }
+  }
+
+  @ReactMethod
+  public void readDirAssets(String directory, Callback callback) {
+    try {
+      AssetManager assetManager = getReactApplicationContext().getAssets();
+      String[] list = assetManager.list(directory);
+
+      WritableArray fileMaps = Arguments.createArray();
+      for (String childFile : list) {
+        WritableMap fileMap = Arguments.createMap();
+
+        fileMap.putString("name", childFile);
+        fileMap.putString("path", childFile);
+        int length = 0;
+        boolean isDirectory = false;
+        try {
+          AssetFileDescriptor assetFileDescriptor = assetManager.openFd(childFile);
+          if (assetFileDescriptor != null) {
+            length = (int) assetFileDescriptor.getLength();
+            assetFileDescriptor.close();
+          }
+        } catch (IOException ex) {
+          //.. ah.. is a directory!
+          isDirectory = true;
+        }
+        fileMap.putInt("size", length);
+        fileMap.putInt("type", isDirectory ? 1 : 0); // if 0, probably a folder..
+
+        fileMaps.pushMap(fileMap);
+      }
+      callback.invoke(null, fileMaps);
+
+    } catch (IOException e) {
+      e.printStackTrace();
+      callback.invoke(makeErrorPayload(e));
     }
   }
 

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -288,7 +288,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
         WritableMap fileMap = Arguments.createMap();
 
         fileMap.putString("name", childFile);
-        String path = String.format("%s/%s", directory, childFile);
+        String path = directory.isEmpty() ? childFile : String.format("%s/%s", directory, childFile); // don't allow / at the start when directory is ""
         fileMap.putString("path", path);
         int length = 0;
         boolean isDirectory = false;

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -328,6 +328,39 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void existsAssets(String filepath, Callback callback) {
+    try {
+      AssetManager assetManager = getReactApplicationContext().getAssets();
+
+      try {
+        String[] list = assetManager.list(filepath);
+        if (list != null && list.length > 0) {
+          callback.invoke(null, true);
+          return;
+        }
+      } catch (Exception ignored) {
+        //.. probably not a directory then
+      }
+
+      // Attempt to open file (win = exists)
+      InputStream fileStream = null;
+      try {
+        fileStream = assetManager.open(filepath);
+        callback.invoke(null, true);
+      } catch (Exception ex) {
+        callback.invoke(null, false); // asset doesn't exist
+      } finally {
+        if (fileStream != null) {
+          fileStream.close();
+        }
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      callback.invoke(makeErrorPayload(ex));
+    }
+  }
+
+  @ReactMethod
   public void copyFile(String source, String destination, Callback callback) {
     try {
       InputStream in = new FileInputStream(source);


### PR DESCRIPTION
Added support for four Android-specific features:
- Reading files from the Android assets folder (via `readFileAssets`) 
- Listing the files available in a folder in the Android assets directory (via `readDirAssets`). 
- Copying a file from the assets folder to a destination folder. (via `copyFileAssets`). This is useful when you need write access to a file that came from the app bundle (e.g. a database file).
- (New!) Determining if a file or folder is available in the Android assets directory (via `existsAssets`).

These methods are necessary as the existing `readFile` and `readDir` functions do not work for files stored in the Android asset folder (e.g. pre-bundled JSON files).

On iOS, these methods will throw an exception ('Not available on this platform') 
Added documentation. 
