### PR TITLE
Add support for following 301/302 redirects on android

### DIFF
--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -50,6 +50,24 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
       int statusCode = connection.getResponseCode();
       int lengthOfFile = connection.getContentLength();
 
+      boolean isRedirect = (
+        statusCode != HttpURLConnection.HTTP_OK &&
+        (
+          statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
+          statusCode == HttpURLConnection.HTTP_MOVED_TEMP
+        )
+      );
+
+      if (isRedirect) {
+        String redirectURL = connection.getHeaderField("Location");
+        connection = (HttpURLConnection) new URL(redirectURL).openConnection();
+        connection.setConnectTimeout(5000);
+        connection.connect();
+
+        statusCode = connection.getResponseCode();
+        lengthOfFile = connection.getContentLength();
+      }
+
       Map<String, List<String>> headers = connection.getHeaderFields();
 
       Map<String, String> headersFlat = new HashMap<String, String>();


### PR DESCRIPTION
This is to address the issue outlined in https://github.com/johanneslumpe/react-native-fs/issues/71, where redirects are not followed in android.

The solution is similar to the one described in the comment section of the issue, but does not recursively call itself on the redirect url (avoids the danger of a stack overflow), and handles both 301/302 status codes.