### PR TITLE
Update RNFS.podspec

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -1,11 +1,19 @@
+require 'json'
+pjson = JSON.parse(File.read('package.json'))
+
 Pod::Spec.new do |s|
 
-  s.name         = "RNFS"
-  s.version      = "1.3.0"
-  s.homepage     = "https://github.com/johanneslumpe/react-native-fs"
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/johanneslumpe/react-native-fs.git" }
-  s.source_files = '*.{h,m}'
-  s.preserve_paths = "**/*.js"
-  s.dependency   'React/Core'
+  s.name            = "RNFS"
+  s.version         = pjson["version"]
+  s.homepage        = "https://github.com/johanneslumpe/react-native-fs"
+  s.summary         = pjson["description"]
+  s.license         = pjson["license"]
+  s.author          = { "Johannes Lumpe" => "johannes@lum.pe" }
+  s.platform        = :ios, "7.0"
+  s.source          = { :git => "https://github.com/johanneslumpe/react-native-fs", :tag => "#{s.version}" }
+  s.source_files    = '*.{h,m}'
+  s.preserve_paths  = "**/*.js"
+  
+  s.dependency 'React/Core'
+
 end


### PR DESCRIPTION
Support for CocoaPods 1.

Also, a side question - are there plans to push tags as well as bump versions in package.json? Currently it says 1.3.0 whereas the latest release on Github is 1.4.0.