### PR TITLE
Use React Native from node_modules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,10 +25,6 @@ android {
     }
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile 'com.facebook.react:react-native:0.12.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
It wasn't probably a desired behaviour. Since maven contains outdated React, that's why it was throwing that the DeviceEventEmitter is not there etc. After changing it to use the node_modules one, it works again and all classes that are available in the currently installed React are working.