### PR TITLE
Add support for background downloads

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -16,7 +16,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 
 @end
 
-@interface Downloader : NSObject <NSURLConnectionDelegate>
+@interface Downloader : NSObject <NSURLSessionDelegate, NSURLSessionDownloadDelegate>
 
 - (void)downloadFile:(DownloadParams*)params;
 - (void)stopDownload;

--- a/Downloader.h
+++ b/Downloader.h
@@ -13,6 +13,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 @property (copy) ErrorCallback errorCallback;         // Something went wrong
 @property (copy) BeginCallback beginCallback;         // Download has started (headers received)
 @property (copy) ProgressCallback progressCallback;   // Download is progressing
+@property        bool background;                     // Whether to continue download when app is in background
 
 @end
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -41,9 +41,11 @@
   }
 
   NSURLSessionConfiguration *config;
-  config = [NSURLSessionConfiguration defaultSessionConfiguration];
-  // TODO: use the following config for session objects:
-  //config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:fromUrl];
+  if (_params.background) {
+    config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:_params.fromUrl];
+  } else {
+    config = [NSURLSessionConfiguration defaultSessionConfiguration];
+  }
 
   _session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
   _task = [_session downloadTaskWithURL:url];

--- a/Downloader.m
+++ b/Downloader.m
@@ -8,7 +8,8 @@
 
 @property (copy) DownloadParams* params;
 
-@property (retain) NSURLConnection* connection;
+@property (retain) NSURLSession* session;
+@property (retain) NSURLSessionTask* task;
 @property (retain) NSNumber* statusCode;
 @property (retain) NSNumber* contentLength;
 @property (retain) NSNumber* bytesWritten;
@@ -27,12 +28,7 @@
 
   NSURL* url = [NSURL URLWithString:_params.fromUrl];
 
-  NSMutableURLRequest* downloadRequest = [NSMutableURLRequest requestWithURL:url
-                                                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                             timeoutInterval:30];
-
   [[NSFileManager defaultManager] createFileAtPath:_params.toFile contents:nil attributes:nil];
-
   _fileHandle = [NSFileHandle fileHandleForWritingAtPath:_params.toFile];
 
   if (!_fileHandle) {
@@ -41,31 +37,26 @@
     return _params.errorCallback(error);
   }
 
-  _connection = [[NSURLConnection alloc] initWithRequest:downloadRequest delegate:self startImmediately:NO];
+  NSURLSessionConfiguration *config;
+  config = [NSURLSessionConfiguration defaultSessionConfiguration];
+  // TODO: use the following config for session objects:
+  //config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:fromUrl];
 
-  [_connection scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
-
-  [_connection start];
+  _session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
+  _task = [_session downloadTaskWithURL:url];
+  [_task resume];
 }
 
-- (void)connection:(NSURLConnection*)connection didFailWithError:(NSError*)error
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didReceiveResponse:(NSURLResponse *)response
 {
-  [_fileHandle closeFile];
+  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)downloadTask.response;
+  _statusCode = [NSNumber numberWithLong:httpResponse.statusCode];
+  _contentLength = [NSNumber numberWithLong:httpResponse.expectedContentLength];
 
-  return _params.errorCallback(error);
+  return _params.beginCallback(_statusCode, _contentLength, httpResponse.allHeaderFields);
 }
 
-- (void)connection:(NSURLConnection*)connection didReceiveResponse:(NSURLResponse*)response
-{
-  NSHTTPURLResponse* httpUrlResponse = (NSHTTPURLResponse*)response;
-
-  _statusCode = [NSNumber numberWithLong:httpUrlResponse.statusCode];
-  _contentLength = [NSNumber numberWithLong: httpUrlResponse.expectedContentLength];
-  
-  return _params.beginCallback(_statusCode, _contentLength, httpUrlResponse.allHeaderFields);
-}
-
-- (void)connection:(NSURLConnection*)connection didReceiveData:(NSData*)data
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(NSData *)data
 {
   if ([_statusCode isEqualToNumber:[NSNumber numberWithInt:200]]) {
     [_fileHandle writeData:data];
@@ -76,16 +67,23 @@
   }
 }
 
-- (void)connectionDidFinishLoading:(NSURLConnection*)connection
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
   [_fileHandle closeFile];
 
   return _params.callback(_statusCode, _bytesWritten);
 }
 
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionTask *)downloadTask didCompleteWithError:(NSError *)error
+{
+  [_fileHandle closeFile];
+  return _params.errorCallback(error);
+}
+
+
 - (void)stopDownload
 {
-  [_connection cancel];
+  [_task cancel];
 }
 
 @end

--- a/Downloader.m
+++ b/Downloader.m
@@ -32,9 +32,12 @@
   _fileHandle = [NSFileHandle fileHandleForWritingAtPath:_params.toFile];
 
   if (!_fileHandle) {
-    NSError* error = [NSError errorWithDomain:@"Downloader" code:NSURLErrorFileDoesNotExist userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"Failed to create target file at path: %@", _params.toFile]}];
+    NSError* error = [NSError errorWithDomain:@"Downloader" code:NSURLErrorFileDoesNotExist
+                              userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat: @"Failed to create target file at path: %@", _params.toFile]}];
 
     return _params.errorCallback(error);
+  } else {
+    [_fileHandle closeFile];
   }
 
   NSURLSessionConfiguration *config;
@@ -47,36 +50,37 @@
   [_task resume];
 }
 
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didReceiveResponse:(NSURLResponse *)response
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)downloadTask.response;
-  _statusCode = [NSNumber numberWithLong:httpResponse.statusCode];
-  _contentLength = [NSNumber numberWithLong:httpResponse.expectedContentLength];
+  if (!_statusCode) {
+    _statusCode = [NSNumber numberWithLong:httpResponse.statusCode];
+    _contentLength = [NSNumber numberWithLong:httpResponse.expectedContentLength];
+    return _params.beginCallback(_statusCode, _contentLength, httpResponse.allHeaderFields);
+  }
 
-  return _params.beginCallback(_statusCode, _contentLength, httpResponse.allHeaderFields);
-}
-
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(NSData *)data
-{
   if ([_statusCode isEqualToNumber:[NSNumber numberWithInt:200]]) {
-    [_fileHandle writeData:data];
-
-    _bytesWritten = [NSNumber numberWithUnsignedInteger:[_bytesWritten unsignedIntegerValue] + data.length];
-
+    _bytesWritten = @(totalBytesWritten);
     return _params.progressCallback(_contentLength, _bytesWritten);
   }
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
-  [_fileHandle closeFile];
+  NSURL *destURL = [NSURL fileURLWithPath:_params.toFile];
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSError *error = nil;
+  [fm removeItemAtURL:destURL error:nil];       // Remove file at destination path, if it exists
+  [fm moveItemAtURL:location toURL:destURL error:&error];
+  if (error) {
+    NSLog(@"RNFS download: unable to move tempfile to destination. %@, %@", error, error.userInfo);
+  }
 
   return _params.callback(_statusCode, _bytesWritten);
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionTask *)downloadTask didCompleteWithError:(NSError *)error
 {
-  [_fileHandle closeFile];
   return _params.errorCallback(error);
 }
 

--- a/FS.common.js
+++ b/FS.common.js
@@ -155,10 +155,10 @@ var RNFS = {
       .catch(convertError);
   },
 
-  downloadFile(fromUrl, toFile, begin, progress) {
+  downloadFile(fromUrl, toFile, begin, progress, options = {}) {
     var jobId = getJobId();
     var subscriptions = [];
-    
+
     if (begin) {
       subscriptions.push(NativeAppEventEmitter.addListener('DownloadBegin-' + jobId, begin));
     }
@@ -167,7 +167,7 @@ var RNFS = {
       subscriptions.push(NativeAppEventEmitter.addListener('DownloadProgress-' + jobId, progress));
     }
 
-    return _downloadFile(fromUrl, toFile, jobId)
+    return _downloadFile(fromUrl, toFile, jobId, options)
       .then(res => {
         subscriptions.forEach(sub => sub.remove());
         return res;

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Create a directory at `filepath`. Automatically creates parents and does not thr
 
 IOS only: If `excludeFromBackup` is true, then `NSURLIsExcludedFromBackupKey` attribute will be set. Apple will *reject* apps for storing offline cache data that does not have this attribute.
 
-### `promise downloadFile(url, filepath [, beginCallback, progressCallback])`
+### `promise downloadFile(url, filepath [, beginCallback, progressCallback, options])`
 
 Download file from `url` to `filepath`. Will overwrite any previously existing file.
 
@@ -267,6 +267,14 @@ If `progressCallback` is provided, it will be invoked continuously and passed a 
 `bytesWritten` (`Number`) - The number of bytes written to the file so far  
 
 Percentage can be computed easily by dividing `bytesWritten` by `contentLength`.
+
+If `options` is provided, it can contain the following property:
+
+`background` (`Boolean`) - Whether to continue downloads when the app is not focused (default: `false`)
+                           This option is currently only available for iOS, and you must [enable
+                           background fetch](https://www.objc.io/issues/5-ios7/multitasking/#background-fetch<Paste>)
+                           for your project in XCode.
+
 
 ### `void stopDownload(jobId)`
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -175,6 +175,7 @@ RCT_EXPORT_METHOD(moveFile:(NSString *)filepath
 RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
                   filepath:(NSString *)filepath
                   jobId:(nonnull NSNumber *)jobId
+                  options:(nonnull NSDictionary *)options
                   callback:(RCTResponseSenderBlock)callback)
 {
 
@@ -182,6 +183,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
 
   params.fromUrl = urlStr;
   params.toFile = filepath;
+  params.background = (BOOL)[options valueForKey:@"background"];
 
   params.callback = ^(NSNumber* statusCode, NSNumber* bytesWritten) {
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,


### PR DESCRIPTION
This was discussed in #80, including a suggestion to use the API implemented here. This PR only includes support for iOS background downloads.

1) Move downloads to use the newer `NSURLSession` APIs (supported in iOS 7 and later)
2) Add an extra `options` arg to `downloadFile()`. If this arg is `{ background: true }`, file downloads will persist when the app is backgrounded or the phone is put to sleep

Note that to use this setting, you need to request the "Background Fetch" capability for your app in XCode. I added a note about this in the Readme.