### PR TITLE
Added progressDivider param to downloadFile method

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -9,6 +9,7 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 
 @property (copy) NSString* fromUrl;
 @property (copy) NSString* toFile;
+@property (copy) NSNumber* progressDivider;
 @property (copy) DownloaderCallback callback;         // Download has finished (data written)
 @property (copy) ErrorCallback errorCallback;         // Something went wrong
 @property (copy) BeginCallback beginCallback;         // Download has started (headers received)

--- a/Downloader.m
+++ b/Downloader.m
@@ -10,6 +10,7 @@
 
 @property (retain) NSURLConnection* connection;
 @property (retain) NSNumber* statusCode;
+@property (retain) NSNumber* lastProgressValue;
 @property (retain) NSNumber* contentLength;
 @property (retain) NSNumber* bytesWritten;
 
@@ -72,7 +73,19 @@
 
     _bytesWritten = [NSNumber numberWithUnsignedInteger:[_bytesWritten unsignedIntegerValue] + data.length];
 
-    return _params.progressCallback(_contentLength, _bytesWritten);
+    if (_params.progressDivider <= 1) {
+        return _params.progressCallback(_contentLength, _bytesWritten);
+    } else {
+        NSLog(@"---Progress callback---");
+        long double progress = Math.round(((double) _bytesWritten * 100) / _contentLength);
+        if (progress % param.progressDivider == 0) {
+            if ((progress != _lastProgressValue) || (_bytesWritten == _contentLength)) {
+                NSLog(@"---Progress callback EMIT--- %zu", progress);
+                _lastProgressValue = [NSNumber numberWithLong:progress];
+                return _params.progressCallback(_contentLength, _bytesWritten);
+            }
+        }
+    }
   }
 }
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -23,7 +23,7 @@
 - (void)downloadFile:(DownloadParams*)params
 {
   _params = params;
-  
+
   _bytesWritten = 0;
 
   NSURL* url = [NSURL URLWithString:_params.fromUrl];
@@ -62,7 +62,7 @@
 
   _statusCode = [NSNumber numberWithLong:httpUrlResponse.statusCode];
   _contentLength = [NSNumber numberWithLong: httpUrlResponse.expectedContentLength];
-  
+
   return _params.beginCallback(_statusCode, _contentLength, httpUrlResponse.allHeaderFields);
 }
 
@@ -71,17 +71,19 @@
   if ([_statusCode isEqualToNumber:[NSNumber numberWithInt:200]]) {
     [_fileHandle writeData:data];
 
-    _bytesWritten = [NSNumber numberWithUnsignedInteger:[_bytesWritten unsignedIntegerValue] + data.length];
+    _bytesWritten = [NSNumber numberWithLong:[_bytesWritten longValue] + data.length];
 
     if (_params.progressDivider <= 1) {
         return _params.progressCallback(_contentLength, _bytesWritten);
     } else {
-        NSLog(@"---Progress callback---");
-        long double progress = Math.round(((double) _bytesWritten * 100) / _contentLength);
-        if (progress % param.progressDivider == 0) {
-            if ((progress != _lastProgressValue) || (_bytesWritten == _contentLength)) {
-                NSLog(@"---Progress callback EMIT--- %zu", progress);
-                _lastProgressValue = [NSNumber numberWithLong:progress];
+        double doubleBytesWritten = (double)[_bytesWritten longValue];
+        double doubleContentLength = (double)[_contentLength longValue];
+        double doublePercents = doubleBytesWritten / doubleContentLength * 100;
+        NSNumber* progress = [NSNumber numberWithUnsignedInt: floor(doublePercents)];
+        if ([progress unsignedIntValue] % [_params.progressDivider integerValue] == 0) {
+            if (([progress unsignedIntValue] != [_lastProgressValue unsignedIntValue]) || ([_bytesWritten unsignedIntegerValue] == [_contentLength longValue])) {
+                NSLog(@"---Progress callback EMIT--- %zu", [progress unsignedIntValue]);
+                _lastProgressValue = [NSNumber numberWithUnsignedInt:[progress unsignedIntValue]];
                 return _params.progressCallback(_contentLength, _bytesWritten);
             }
         }

--- a/FS.common.js
+++ b/FS.common.js
@@ -155,7 +155,7 @@ var RNFS = {
       .catch(convertError);
   },
 
-  downloadFile(fromUrl, toFile, begin, progress) {
+  downloadFile(fromUrl, toFile, begin, progress, progressDivider = 1) {
     var jobId = getJobId();
     var subscriptions = [];
     
@@ -167,7 +167,7 @@ var RNFS = {
       subscriptions.push(NativeAppEventEmitter.addListener('DownloadProgress-' + jobId, progress));
     }
 
-    return _downloadFile(fromUrl, toFile, jobId)
+    return _downloadFile(fromUrl, toFile, jobId, progressDivider)
       .then(res => {
         subscriptions.forEach(sub => sub.remove());
         return res;

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Create a directory at `filepath`. Automatically creates parents and does not thr
 
 IOS only: If `excludeFromBackup` is true, then `NSURLIsExcludedFromBackupKey` attribute will be set. Apple will *reject* apps for storing offline cache data that does not have this attribute.
 
-### `promise downloadFile(url, filepath [, beginCallback, progressCallback])`
+### `promise downloadFile(url, filepath [, beginCallback, progressCallback, progressDivider])`
 
 Download file from `url` to `filepath`. Will overwrite any previously existing file.
 
@@ -264,9 +264,13 @@ If `beginCallback` is provided, it will be invoked once upon download starting w
 If `progressCallback` is provided, it will be invoked continuously and passed a single argument with the following properties:
 
 `contentLength` (`Number`) - The total size in bytes of the download resource  
-`bytesWritten` (`Number`) - The number of bytes written to the file so far  
+`bytesWritten` (`Number`) - The number of bytes written to the file so far
 
-Percentage can be computed easily by dividing `bytesWritten` by `contentLength`.
+If `progressDivider`(`Number`) is provided, it will return progress events that divided by progressDivider
+
+For example, if `progressDivider` = 10, you will receive only ten callbacks for this values of progress: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
+Use it for performance issues.
+If `progressDivider` = 1, you will receive all `progressCallback` calls, default value is 1.
 
 ### `void stopDownload(jobId)`
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -175,6 +175,7 @@ RCT_EXPORT_METHOD(moveFile:(NSString *)filepath
 RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
                   filepath:(NSString *)filepath
                   jobId:(nonnull NSNumber *)jobId
+                  progressDivider:(nonnull NSNumber *)progressDivider
                   callback:(RCTResponseSenderBlock)callback)
 {
 
@@ -182,6 +183,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSString *)urlStr
 
   params.fromUrl = urlStr;
   params.toFile = filepath;
+  params.progressDivider = progressDivider;
 
   params.callback = ^(NSNumber* statusCode, NSNumber* bytesWritten) {
     NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,

--- a/android/src/main/java/com/rnfs/DownloadParams.java
+++ b/android/src/main/java/com/rnfs/DownloadParams.java
@@ -19,6 +19,7 @@ public class DownloadParams {
   
   public URL src;
   public File dest;
+  public float progressDivider;
   public OnTaskCompleted onTaskCompleted;
   public OnDownloadBegin onDownloadBegin;
   public OnDownloadProgress onDownloadProgress;

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -81,12 +81,16 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         }
 
         total += count;
-        double progress = Math.round(((double) total * 100) / lengthOfFile);
-        if (progress % 10 == 0) {
-            if ((progress != lastProgressValue) || (total == lengthOfFile)) {
-                Log.d("Downloader", "EMIT: " + String.valueOf(progress) + ", TOTAL:" + String.valueOf(total));
-                lastProgressValue = progress;
-                publishProgress(new int[]{lengthOfFile, total});
+        if (param.progressDivider <= 1) {
+            publishProgress(new int[]{lengthOfFile, total});
+        } else {
+            double progress = Math.round(((double) total * 100) / lengthOfFile);
+            if (progress % param.progressDivider == 0) {
+                if ((progress != lastProgressValue) || (total == lengthOfFile)) {
+                    Log.d("Downloader", "EMIT: " + String.valueOf(progress) + ", TOTAL:" + String.valueOf(total));
+                    lastProgressValue = progress;
+                    publishProgress(new int[]{lengthOfFile, total});
+                }
             }
         }
         output.write(data, 0, count);

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -71,6 +71,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
       byte data[] = new byte[8 * 1024];
       int total = 0;
       int count;
+      double lastProgressValue = 0;
 
       while ((count = input.read(data)) != -1) {
         if (mAbort.get()) {
@@ -78,7 +79,14 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         }
 
         total += count;
-        publishProgress(new int[] { lengthOfFile, total });
+        double progress = Math.round(((double) total * 100) / lengthOfFile);
+        if (progress % 10 == 0) {
+            if ((progress != lastProgressValue) || (total == lengthOfFile)) {
+                Log.d("Downloader", "EMIT: " + String.valueOf(progress) + ", TOTAL:" + String.valueOf(total));
+                lastProgressValue = progress;
+                publishProgress(new int[]{lengthOfFile, total});
+            }
+        }
         output.write(data, 0, count);
       }
 

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -13,6 +13,8 @@ import java.net.HttpURLConnection;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import android.util.Log;
+
 import android.os.AsyncTask;
 
 public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult> {

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -220,7 +220,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void downloadFile(String urlStr, final String filepath, final int jobId, final Callback callback) {
+  public void downloadFile(String urlStr, final String filepath, final int jobId, float progressDivider, final Callback callback) {
     try {
       File file = new File(filepath);
       URL url = new URL(urlStr);
@@ -229,6 +229,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
 
       params.src = url;
       params.dest = file;
+      params.progressDivider = progressDivider;
 
       params.onTaskCompleted = new DownloadParams.OnTaskCompleted() {
         public void onTaskCompleted(DownloadResult res) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Native filesystem access for react-native",
   "main": "FS.common.js",
   "scripts": {


### PR DESCRIPTION
Added `progressDivider` param to `downloadFile` method.
It helps filtering progressCallback events, emitting all events may occur performance issues on iOS and Android.

For example, if `progressDivider` = 10, you will receive only ten callbacks for this values of progress: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
Use it for performance issues.
If `progressDivider` = 1, you will receive all `progressCallback` calls, the default value is equal to 1.