### PR TITLE
Use UUID for background download identifier

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -42,7 +42,8 @@
 
   NSURLSessionConfiguration *config;
   if (_params.background) {
-    config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:_params.fromUrl];
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:uuid];
   } else {
     config = [NSURLSessionConfiguration defaultSessionConfiguration];
   }


### PR DESCRIPTION
See previous discussion on #100 

I realized that I didn't run into this problem because I'm downloading signed urls which are unique each time. Now if the url has been previously downloaded, no error should occur.