### PR TITLE
ProgressDivider iOS fix & updates on every 1% of progress fix

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -68,7 +68,7 @@
   if ([_statusCode isEqualToNumber:[NSNumber numberWithInt:200]]) {
     _bytesWritten = @(totalBytesWritten);
 
-    if (_params.progressDivider <= 1) {
+    if (_params.progressDivider <= 0) {
       return _params.progressCallback(_contentLength, _bytesWritten);
     } else {
       double doubleBytesWritten = (double)[_bytesWritten longValue];

--- a/Downloader.m
+++ b/Downloader.m
@@ -68,7 +68,7 @@
   if ([_statusCode isEqualToNumber:[NSNumber numberWithInt:200]]) {
     _bytesWritten = @(totalBytesWritten);
 
-    if (_params.progressDivider <= 0) {
+    if (_params.progressDivider.integerValue <= 0) {
       return _params.progressCallback(_contentLength, _bytesWritten);
     } else {
       double doubleBytesWritten = (double)[_bytesWritten longValue];

--- a/FS.common.js
+++ b/FS.common.js
@@ -192,7 +192,7 @@ var RNFS = {
       toFile: options.toFile,
       headers: options.headers || {},
       background: !!options.background,
-      progressDivider: options.progressDivider || 1
+      progressDivider: options.progressDivider || 0
     };
 
     return _downloadFile(bridgeOptions)

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ If `options.progressDivider`(`Number`) is provided, it will return progress even
 
 For example, if `progressDivider` = 10, you will receive only ten callbacks for this values of progress: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 Use it for performance issues.
-If `progressDivider` = 1, you will receive all `progressCallback` calls, default value is 1.
+If `progressDivider` = 0, you will receive all `progressCallback` calls, default value is 0.
 
 (IOS only): `options.background` (`Boolean`) - Whether to continue downloads when the app is not focused (default: `false`)
                            This option is currently only available for iOS, and you must [enable

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -111,7 +111,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         }
 
         total += count;
-        if (param.progressDivider.integerValue <= 0) {
+        if (param.progressDivider <= 0) {
             publishProgress(new int[]{lengthOfFile, total});
         } else {
             double progress = Math.round(((double) total * 100) / lengthOfFile);

--- a/android/src/main/java/com/rnfs/Downloader.java
+++ b/android/src/main/java/com/rnfs/Downloader.java
@@ -111,7 +111,7 @@ public class Downloader extends AsyncTask<DownloadParams, int[], DownloadResult>
         }
 
         total += count;
-        if (param.progressDivider <= 1) {
+        if (param.progressDivider.integerValue <= 0) {
             publishProgress(new int[]{lengthOfFile, total});
         } else {
             double progress = Math.round(((double) total * 100) / lengthOfFile);


### PR DESCRIPTION
This commit fixes two issues:
* On iOS when the progress divider was checked if it was 1, the check was being done on an `NSNumber` which meant it always failed. Converted it to an integer to fix.
* Originally the code used a `progressDivider <= 1` to indicate that it should send all calls across the bridge. It's quite a common use case to want to be updated on every full percentage though, so I have changed this to use a `progressDivider <= 0` as an indication that all progress calls should be sent across the bridge. This fix also changes the default progressDivider value to be 0 & updates the docs to reflect this