### PR TITLE
Upload File Example documentation update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ RNFS.uploadFiles({
       'hello': 'world',
     },
     begin: uploadBegin,
-    progress: uploadProgress
+    progressCallback: uploadProgress
   })
   .then((response) => {
     if (response.statusCode == 200) {


### PR DESCRIPTION
Changed the uploadFiles options object to use **progressCallback** instead of **progress** because that is how it's named in FS.common.js.  This tripped me up until I dug into the source to figure out what the callback is actually named.

Note that the downloadFile option is named **progress** both the README example and the FS.common.js file.  Not sure if it's better to rename the uploadFiles option to match downloadFile option or not.

Thanks, this is a great extension to React Native.