### PR TITLE
Fixed iOS duplicate symbol errors with other plugins

### DIFF
--- a/Downloader.h
+++ b/Downloader.h
@@ -5,7 +5,7 @@ typedef void (^ErrorCallback)(NSError*);
 typedef void (^BeginCallback)(NSNumber*, NSNumber*, NSDictionary*);
 typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 
-@interface DownloadParams : NSObject
+@interface RNFSDownloadParams : NSObject
 
 @property (copy) NSString* fromUrl;
 @property (copy) NSString* toFile;
@@ -20,9 +20,9 @@ typedef void (^ProgressCallback)(NSNumber*, NSNumber*);
 
 @end
 
-@interface Downloader : NSObject <NSURLSessionDelegate, NSURLSessionDownloadDelegate>
+@interface RNFSDownloader : NSObject <NSURLSessionDelegate, NSURLSessionDownloadDelegate>
 
-- (void)downloadFile:(DownloadParams*)params;
+- (void)downloadFile:(RNFSDownloadParams*)params;
 - (void)stopDownload;
 
 @end

--- a/Downloader.m
+++ b/Downloader.m
@@ -1,12 +1,12 @@
 #import "Downloader.h"
 
-@implementation DownloadParams
+@implementation RNFSDownloadParams
 
 @end
 
-@interface Downloader()
+@interface RNFSDownloader()
 
-@property (copy) DownloadParams* params;
+@property (copy) RNFSDownloadParams* params;
 
 @property (retain) NSURLSession* session;
 @property (retain) NSURLSessionTask* task;
@@ -19,9 +19,9 @@
 
 @end
 
-@implementation Downloader
+@implementation RNFSDownloader
 
-- (void)downloadFile:(DownloadParams*)params
+- (void)downloadFile:(RNFSDownloadParams*)params
 {
   _params = params;
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -238,7 +238,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  DownloadParams* params = [DownloadParams alloc];
+  RNFSDownloadParams* params = [RNFSDownloadParams alloc];
 
   NSNumber* jobId = options[@"jobId"];
   params.fromUrl = options[@"fromUrl"];
@@ -280,7 +280,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
 
   if (!self.downloaders) self.downloaders = [[NSMutableDictionary alloc] init];
 
-  Downloader* downloader = [Downloader alloc];
+  RNFSDownloader* downloader = [RNFSDownloader alloc];
 
   [downloader downloadFile:params];
 
@@ -289,7 +289,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
 
 RCT_EXPORT_METHOD(stopDownload:(nonnull NSNumber *)jobId)
 {
-  Downloader* downloader = [self.downloaders objectForKey:[jobId stringValue]];
+  RNFSDownloader* downloader = [self.downloaders objectForKey:[jobId stringValue]];
 
   if (downloader != nil) {
     [downloader stopDownload];
@@ -300,7 +300,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  UploadParams* params = [UploadParams alloc];
+  RNFSUploadParams* params = [RNFSUploadParams alloc];
 
   NSNumber* jobId = options[@"jobId"];
   params.toUrl = options[@"toUrl"];
@@ -342,7 +342,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
 
   if (!self.uploaders) self.uploaders = [[NSMutableDictionary alloc] init];
 
-  Uploader* uploader = [Uploader alloc];
+  RNFSUploader* uploader = [RNFSUploader alloc];
 
   [uploader uploadFiles:params];
 
@@ -351,7 +351,7 @@ RCT_EXPORT_METHOD(uploadFiles:(NSDictionary *)options
 
 RCT_EXPORT_METHOD(stopUpload:(nonnull NSNumber *)jobId)
 {
-  Uploader* uploader = [self.uploaders objectForKey:[jobId stringValue]];
+  RNFSUploader* uploader = [self.uploaders objectForKey:[jobId stringValue]];
 
   if (uploader != nil) {
     [uploader stopUpload];

--- a/Uploader.h
+++ b/Uploader.h
@@ -6,7 +6,7 @@ typedef void (^UploadErrorCallback)(NSError*);
 typedef void (^UploadBeginCallback)();
 typedef void (^UploadProgressCallback)(NSNumber*, NSNumber*);
 
-@interface UploadParams : NSObject
+@interface RNFSUploadParams : NSObject
 
 @property (copy) NSString* toUrl;
 @property (copy) NSArray* files;
@@ -20,9 +20,9 @@ typedef void (^UploadProgressCallback)(NSNumber*, NSNumber*);
 
 @end
 
-@interface Uploader : NSObject <NSURLConnectionDelegate>
+@interface RNFSUploader : NSObject <NSURLConnectionDelegate>
 
-- (void)uploadFiles:(UploadParams*)params;
+- (void)uploadFiles:(RNFSUploadParams*)params;
 - (void)stopUpload;
 
 @end

--- a/Uploader.m
+++ b/Uploader.m
@@ -1,20 +1,20 @@
 #import "Uploader.h"
 
-@implementation UploadParams
+@implementation RNFSUploadParams
 
 @end
 
-@interface Uploader()
+@interface RNFSUploader()
 
-@property (copy) UploadParams* params;
+@property (copy) RNFSUploadParams* params;
 
 @property (retain) NSURLSessionDataTask* task;
 
 @end
 
-@implementation Uploader
+@implementation RNFSUploader
 
-- (void)uploadFiles:(UploadParams*)params
+- (void)uploadFiles:(RNFSUploadParams*)params
 {
   _params = params;
 


### PR DESCRIPTION
The Uploader & Downloader classes cause linker errors with other plugins that also implement classes that are called Uploader or Downloader. E.g. this happens when using react-native-fs in combination with Firebase Crash reporting.
Basically, both plugins are at fault for not implementing unique class names. This commit adds the RNFS prefix for these classes.

![image](https://cloud.githubusercontent.com/assets/6184593/17015358/1591d7d4-4f2a-11e6-9457-f735538d1728.png)
