### PR TITLE
Make mkdir options optional

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -118,9 +118,7 @@ type FSInfoResult = {
 
 var RNFS = {
 
-  mkdir(filepath: string, options: MkdirOptions): Promise<void> {
-    options = options || {};
-
+  mkdir(filepath: string, options: MkdirOptions = {}): Promise<void> {
     return RNFSManager.mkdir(filepath, options).then(() => void 0);
   },
 


### PR DESCRIPTION
This PR simplifies the code slightly by using a Javascript default value for `mkdir`'s `options` parameter. It also fixes a flow error that otherwise occurs when `mkdir` is called with only one argument.