### PR TITLE
Remove file:// from paths

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -24,6 +24,8 @@ var getJobId = () => {
   return jobId;
 };
 
+var normalizeFilePath = (path: string) => (path.startsWith('file://') ? path.slice(7) : path);
+
 type MkdirOptions = {
   RNFSURLIsExcludedFromBackupKey?: boolean;
 };
@@ -119,15 +121,15 @@ type FSInfoResult = {
 var RNFS = {
 
   mkdir(filepath: string, options: MkdirOptions = {}): Promise<void> {
-    return RNFSManager.mkdir(filepath, options).then(() => void 0);
+    return RNFSManager.mkdir(normalizeFilePath(filepath), options).then(() => void 0);
   },
 
   moveFile(filepath: string, destPath: string): Promise<void> {
-    return RNFSManager.moveFile(filepath, destPath).then(() => void 0);
+    return RNFSManager.moveFile(normalizeFilePath(filepath), normalizeFilePath(destPath)).then(() => void 0);
   },
 
   copyFile(filepath: string, destPath: string): Promise<void> {
-    return RNFSManager.copyFile(filepath, destPath).then(() => void 0);
+    return RNFSManager.copyFile(normalizeFilePath(filepath), normalizeFilePath(destPath)).then(() => void 0);
   },
 
   pathForBundle(bundleNamed: string): Promise<string> {
@@ -139,11 +141,11 @@ var RNFS = {
   },
 
   unlink(filepath: string): Promise<void> {
-    return RNFSManager.unlink(filepath).then(() => void 0);
+    return RNFSManager.unlink(normalizeFilePath(filepath)).then(() => void 0);
   },
 
   exists(filepath: string): Promise<boolean> {
-    return RNFSManager.exists(filepath);
+    return RNFSManager.exists(normalizeFilePath(filepath));
   },
 
   stopDownload(jobId: number): void {
@@ -155,7 +157,7 @@ var RNFS = {
   },
 
   readDir(dirpath: string): Promise<ReadDirItem[]> {
-    return RNFSManager.readDir(dirpath).then(files => {
+    return RNFSManager.readDir(normalizeFilePath(dirpath)).then(files => {
       return files.map(file => ({
         name: file.name,
         path: file.path,
@@ -168,13 +170,13 @@ var RNFS = {
 
   // Node style version (lowercase d). Returns just the names
   readdir(dirpath: string): Promise<string[]> {
-    return RNFS.readDir(dirpath).then(files => {
+    return RNFS.readDir(normalizeFilePath(dirpath)).then(files => {
       return files.map(file => file.name);
     });
   },
 
   stat(filepath: string): Promise<StatResult> {
-    return RNFSManager.stat(filepath).then((result) => {
+    return RNFSManager.stat(normalizeFilePath(filepath)).then((result) => {
       return {
         'ctime': new Date(result.ctime * 1000),
         'mtime': new Date(result.mtime * 1000),
@@ -199,7 +201,7 @@ var RNFS = {
       }
     }
 
-    return RNFSManager.readFile(filepath).then((b64) => {
+    return RNFSManager.readFile(normalizeFilePath(filepath)).then((b64) => {
       var contents;
 
       if (options.encoding === 'utf8') {
@@ -241,7 +243,7 @@ var RNFS = {
       throw new Error('Invalid encoding type "' + options.encoding + '"');
     }
 
-    return RNFSManager.writeFile(filepath, b64).then(() => void 0);
+    return RNFSManager.writeFile(normalizeFilePath(filepath), b64).then(() => void 0);
   },
 
   appendFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
@@ -269,7 +271,7 @@ var RNFS = {
       throw new Error('Invalid encoding type "' + options.encoding + '"');
     }
 
-    return RNFSManager.appendFile(filepath, b64);
+    return RNFSManager.appendFile(normalizeFilePath(filepath), b64);
   },
 
   downloadFile(options: DownloadFileOptions): { jobId: number, promise: Promise<DownloadResult> } {
@@ -294,7 +296,7 @@ var RNFS = {
     var bridgeOptions = {
       jobId: jobId,
       fromUrl: options.fromUrl,
-      toFile: options.toFile,
+      toFile: normalizeFilePath(options.toFile),
       headers: options.headers || {},
       background: !!options.background,
       progressDivider: options.progressDivider || 0


### PR DESCRIPTION
This PR adds a small function `normalizeFilePath` that removes the `file://` prefix from paths before operating on them.

On Android, local photos must be prefixed with `file://` to be loaded by the `<Image />` component, and the [react-native-camera](https://github.com/lwansbrough/react-native-camera) library automatically adds that prefix to the paths returned. This change allows those paths to be passed to this library for filesystem operations without being sanitized by the caller.