### PR TITLE
Update mkdir param in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Also recursively deletes directories (works like Linux `rm -rf`).
 
 check if the item exist at `filepath`. If the item does not exist, return false.
 
-### `mkdir(filepath: string, excludeFromBackup?: boolean): Promise<void>`
+### `mkdir(filepath: string, options?: { excludeFromBackup: boolean }): Promise<void>`
 
 Create a directory at `filepath`. Automatically creates parents and does not throw if already exists (works like Linux `mkdir -p`).
 


### PR DESCRIPTION
The source looks like `mkdir` is expecting `filepath` and an `options` object but the docs say a boolean. Update the docs to show an object.