### PR TITLE
Add a comment about RNFS.MainBundlePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ public class MainApplication extends Application implements ReactApplication {
 var RNFS = require('react-native-fs');
 
 // get a list of files and directories in the main bundle
-RNFS.readDir(RNFS.MainBundlePath)
+RNFS.readDir(RNFS.MainBundlePath) // On Android, use "RNFS.DocumentDirectoryPath" (MainBundlePath is not defined)
   .then((result) => {
     console.log('GOT RESULT', result);
 


### PR DESCRIPTION
Add a comment about RNFS.MainBundlePath not existing on Android.

The first example should work on Android, since it's probably the first thing anyone will try when getting started - I certainly was confused for a few minutes as to why the example didn't work.

Also fixes #133 - another person who was confused when getting started