### PR TITLE
Check if callbacks are functions

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -332,7 +332,7 @@ var RNFS = {
     if (options.begin) {
       subscriptions.push(NativeAppEventEmitter.addListener('UploadBegin-' + jobId, options.begin));
     }
-    if (options.beginCallback) {
+    if (options.beginCallback && options.beginCallback instanceof Function) {
       // Deprecated
       subscriptions.push(NativeAppEventEmitter.addListener('UploadBegin-' + jobId, options.beginCallback));
     }
@@ -340,7 +340,7 @@ var RNFS = {
     if (options.progress) {
       subscriptions.push(NativeAppEventEmitter.addListener('UploadProgress-' + jobId, options.progress));
     }
-    if (options.progressCallback) {
+    if (options.progressCallback && options.progressCallback instanceof Function) {
       // Deprecated
       subscriptions.push(NativeAppEventEmitter.addListener('UploadProgress-' + jobId, options.progressCallback));
     }


### PR DESCRIPTION
This fixes a Flow complaint that `NativeAppEventEmitter.addListener` requires a function, without having to add `beginCallback` and `progressCallback` to the options object (preferable because they're deprecated).