### PR TITLE
Add nil check on download completion callback

### DIFF
--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -266,8 +266,10 @@ RCT_EXPORT_METHOD(downloadFile:(NSDictionary *)options
   params.progressDivider = progressDivider;
 
   params.completeCallback = ^(NSNumber* statusCode, NSNumber* bytesWritten) {
-    NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId,
-                                                                                     @"statusCode": statusCode}];
+    NSMutableDictionary* result = [[NSMutableDictionary alloc] initWithDictionary: @{@"jobId": jobId}];
+    if (statusCode) {
+      [result setObject:statusCode forKey: @"statusCode"];
+    }
     if (bytesWritten) {
       [result setObject:bytesWritten forKey: @"bytesWritten"];
     }


### PR DESCRIPTION
Hi, 

With version 1.5.1 on iOS, my app crash when I go to home during a download and back to the app with the following error `'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[3]`. 

I added a nil check to avoid the error.