### PR TITLE
Add hash method for both iOS and Android

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -218,6 +218,10 @@ var RNFS = {
     });
   },
 
+  hash(filepath: string, algorithm: string): Promise<string> {
+    return RNFSManager.hash(filepath, algorithm);
+  },
+
   writeFile(filepath: string, contents: string, encodingOrOptions?: any): Promise<void> {
     var b64;
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ Also recursively deletes directories (works like Linux `rm -rf`).
 
 check if the item exist at `filepath`. If the item does not exist, return false.
 
+### `hash(filepath: string, algorithm: string): Promise<string>`
+
+Reads the file at `path` and returns its checksum as determined by `algorithm`, which can be one of `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`.
+
 ### `mkdir(filepath: string, options?: MkdirOptions): Promise<void>`
 
 ```


### PR DESCRIPTION
This PR adds a hash method to natively calculate file checksums using MD5 or SHA algorithms. Any feedback would be welcome!