### PR TITLE
Use existing NSURLSessionTaskDelegate method

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -86,7 +86,7 @@
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-  return _params.errorCallback(error);
+  return error ? _params.errorCallback(error) : nil;
 }
 
 

--- a/Downloader.m
+++ b/Downloader.m
@@ -84,7 +84,7 @@
   return _params.completeCallback(_statusCode, _bytesWritten);
 }
 
-- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionTask *)downloadTask didCompleteWithError:(NSError *)error
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
   return _params.errorCallback(error);
 }


### PR DESCRIPTION
This PR fixes error not being thrown when download finishes with error due to eg. lost network connection.