### PR TITLE
iOS stopDownload Race Condition

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -107,15 +107,17 @@
 
 - (void)stopDownload
 {
-  [_task cancel];
+  if (_task.state == NSURLSessionTaskStateRunning) {
+    [_task cancel];
 
-  NSError *error = [NSError errorWithDomain:@"RNFS"
-                                       code:@"Aborted"
-                                   userInfo:@{
-                                     NSLocalizedDescriptionKey: @"Download has been aborted"
-                                   }];
+    NSError *error = [NSError errorWithDomain:@"RNFS"
+                                         code:@"Aborted"
+                                     userInfo:@{
+                                       NSLocalizedDescriptionKey: @"Download has been aborted"
+                                     }];
 
-  return _params.errorCallback(error);
+    return _params.errorCallback(error);
+  }
 }
 
 @end


### PR DESCRIPTION
When using RNFS's `downloadFile` functionality, the user's javascript component may call `stopDownload` after the file has actually completed downloading on iOS. Because of a delay between communicating between javascript and iOS, the javascript component may not have executed its `completeCallback` despite it being queued on the native side. This means that the javascript component "thinks" that the download is still occurring, so it may call stopDownload.

But, because the download has completed, the success and complete callbacks have been discarded by React Native. **This triggers an error that reads "Callback with id #: undefined.undefined() not found".**

This PR includes a simple check to only cancel the download if it is still downloading, thus avoiding the race condition that causes the above error.