### PR TITLE
Fix ctime/utime attributes on .stat()

### DIFF
--- a/FS.common.js
+++ b/FS.common.js
@@ -43,6 +43,8 @@ type StatResult = {
   path: string;     // The absolute path to the item
   size: string;     // Size in bytes
   mode: number;     // UNIX file mode
+  ctime: number;    // Created date
+  utime: number;    // Updated date
   isFile: () => boolean;        // Is the file just a file?
   isDirectory: () => boolean;   // Is the file a directory?
 };


### PR DESCRIPTION
This fixes the .stat() results so that ctime/utime come through as expected. Looks like it was just an oversight. Fixes #222.