### PR TITLE
add support for react-native v0.40.0

### DIFF
--- a/IntegrationTests/AppDelegate.m
+++ b/IntegrationTests/AppDelegate.m
@@ -9,7 +9,7 @@
 
 #import "AppDelegate.h"
 
-#import "RCTRootView.h"
+#import <React/RCTRootView.h>
 
 @implementation AppDelegate
 

--- a/IntegrationTests/IntegrationTestsTests/IntegrationTestsTests.m
+++ b/IntegrationTests/IntegrationTestsTests/IntegrationTestsTests.m
@@ -12,7 +12,7 @@
 
 #import <RCTTest/RCTTestRunner.h>
 
-#import "RCTAssert.h"
+#import <React/RCTAssert.h>
 
 @interface IntegrationTestsTests : XCTestCase
 

--- a/RNFSManager.h
+++ b/RNFSManager.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Johannes Lumpe. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
-#import "RCTLog.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
 
 @interface RNFSManager : NSObject <RCTBridgeModule>
 

--- a/RNFSManager.m
+++ b/RNFSManager.m
@@ -7,11 +7,11 @@
 //
 
 #import "RNFSManager.h"
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "NSArray+Map.h"
 #import "Downloader.h"
 #import "Uploader.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
 #import <CommonCrypto/CommonDigest.h>
 
 @interface RNFSManager()


### PR DESCRIPTION
This adds support for react-native v0.40.0 - https://github.com/facebook/react-native/releases/tag/v0.40.0 - which introduced a breaking change moving all iOS headers from `"RCTModule.h"` to `<React/RCTModule.h>`.