### PR TITLE
Fix URL Encode

### DIFF
--- a/Downloader.m
+++ b/Downloader.m
@@ -27,7 +27,7 @@
 
   _bytesWritten = 0;
 
-  NSURL* url = [NSURL URLWithString:_params.fromUrl];
+  NSURL* url = [NSURL URLWithString:[_params.fromUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 
   [[NSFileManager defaultManager] createFileAtPath:_params.toFile contents:nil attributes:nil];
   _fileHandle = [NSFileHandle fileHandleForWritingAtPath:_params.toFile];

--- a/android/src/main/java/com/rnfs/RNFSManager.java
+++ b/android/src/main/java/com/rnfs/RNFSManager.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
@@ -481,7 +482,7 @@ public class RNFSManager extends ReactContextBaseJavaModule {
   public void downloadFile(final ReadableMap options, final Promise promise) {
     try {
       File file = new File(options.getString("toFile"));
-      URL url = new URL(options.getString("fromUrl"));
+      URL url = new URL(URLEncoder.encode(options.getString("fromUrl"), "UTF-8"));
       final int jobId = options.getInt("jobId");
       ReadableMap headers = options.getMap("headers");
       int progressDivider = options.getInt("progressDivider");


### PR DESCRIPTION
I found out a error about url encode
When download url is **test.cloudfront.net/Cases & Bags/example.mp4** , the actually url is **test.cloudfront.net/Cases**.

It kill my time...  😔😔😔😔😔