### PR TITLE
fix adding RNFS with CocoaPods

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license         = pjson["license"]
   s.author          = { "Johannes Lumpe" => "johannes@lum.pe" }
   s.platform        = :ios, "7.0"
-  s.source          = { :git => "https://github.com/johanneslumpe/react-native-fs", :tag => "#{s.version}" }
+  s.source          = { :git => "https://github.com/johanneslumpe/react-native-fs", :tag => "v#{s.version}" }
   s.source_files    = '*.{h,m}'
   s.preserve_paths  = "**/*.js"
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs",
-  "version": "v2.1.0-rc.1",
+  "version": "2.1.0-rc.1",
   "description": "Native filesystem access for react-native",
   "main": "FS.common.js",
   "scripts": {


### PR DESCRIPTION
currently if you try to add this package with CocoaPods you will get:
```
[!] Invalid `RNFS.podspec` file: Malformed version number string v2.1.0-rc.1.

 #  from {...}/node_modules/react-native-fs/RNFS.podspec:13
 #  -------------------------------------------
 #    s.platform        = :ios, "7.0"
 >    s.source          = { :git => "https://github.com/johanneslumpe/react-native-fs", :tag => "#{s.version}" }
 #    s.source_files    = '*.{h,m}'
 #  -------------------------------------------
```

because there is 'v' in package.json version. This pr will fix that